### PR TITLE
Add test PBA search script, remove dataset assumptions

### DIFF
--- a/pba/augmentation_transforms.py
+++ b/pba/augmentation_transforms.py
@@ -47,9 +47,9 @@ def pil_wrap(img, dataset):
             (img * STDS[dataset] + MEANS[dataset]) * 255.0)).convert('RGBA')
 
 
-def pil_unwrap(pil_img, dataset):
+def pil_unwrap(pil_img, dataset, image_size):
     """Converts the PIL img to a numpy array."""
-    pic_array = (np.array(pil_img.getdata()).reshape((32, 32, 4)) / 255.0)
+    pic_array = (np.array(pil_img.getdata()).reshape((image_size, image_size, 4)) / 255.0)
     i1, i2 = np.where(pic_array[:, :, 3] == 0)
     pic_array = (pic_array[:, :, :3] - MEANS[dataset]) / STDS[dataset]
     pic_array[i1, i2] = [0, 0, 0]
@@ -78,7 +78,7 @@ def apply_policy(policy, img, dset, image_size):
         xform_fn = NAME_TO_TRANSFORM[name].pil_transformer(
             probability, level, image_size)
         pil_img = xform_fn(pil_img)
-    return pil_unwrap(pil_img, dset)
+    return pil_unwrap(pil_img, dset, image_size)
 
 
 def random_flip(x):
@@ -278,7 +278,7 @@ def _posterize_impl(pil_img, level):
 posterize = TransformT('Posterize', _posterize_impl)
 
 
-def _shear_x_impl(pil_img, level):
+def _shear_x_impl(pil_img, level, image_size):
     """Applies PIL ShearX to `pil_img`.
 
   The ShearX operation shears the image along the horizontal axis with `level`
@@ -295,13 +295,13 @@ def _shear_x_impl(pil_img, level):
     level = float_parameter(level, 0.3)
     if random.random() > 0.5:
         level = -level
-    return pil_img.transform((32, 32), Image.AFFINE, (1, level, 0, 0, 1, 0))
+    return pil_img.transform((image_size, image_size), Image.AFFINE, (1, level, 0, 0, 1, 0))
 
 
 shear_x = TransformT('ShearX', _shear_x_impl)
 
 
-def _shear_y_impl(pil_img, level):
+def _shear_y_impl(pil_img, level, image_size):
     """Applies PIL ShearY to `pil_img`.
 
   The ShearY operation shears the image along the vertical axis with `level`
@@ -318,13 +318,13 @@ def _shear_y_impl(pil_img, level):
     level = float_parameter(level, 0.3)
     if random.random() > 0.5:
         level = -level
-    return pil_img.transform((32, 32), Image.AFFINE, (1, 0, 0, level, 1, 0))
+    return pil_img.transform((image_size, image_size), Image.AFFINE, (1, 0, 0, level, 1, 0))
 
 
 shear_y = TransformT('ShearY', _shear_y_impl)
 
 
-def _translate_x_impl(pil_img, level):
+def _translate_x_impl(pil_img, level, image_size):
     """Applies PIL TranslateX to `pil_img`.
 
   Translate the image in the horizontal direction by `level`
@@ -341,13 +341,13 @@ def _translate_x_impl(pil_img, level):
     level = int_parameter(level, 10)
     if random.random() > 0.5:
         level = -level
-    return pil_img.transform((32, 32), Image.AFFINE, (1, 0, level, 0, 1, 0))
+    return pil_img.transform((image_size, image_size), Image.AFFINE, (1, 0, level, 0, 1, 0))
 
 
 translate_x = TransformT('TranslateX', _translate_x_impl)
 
 
-def _translate_y_impl(pil_img, level):
+def _translate_y_impl(pil_img, level, image_size):
     """Applies PIL TranslateY to `pil_img`.
 
   Translate the image in the vertical direction by `level`
@@ -364,7 +364,7 @@ def _translate_y_impl(pil_img, level):
     level = int_parameter(level, 10)
     if random.random() > 0.5:
         level = -level
-    return pil_img.transform((32, 32), Image.AFFINE, (1, 0, 0, 0, 1, level))
+    return pil_img.transform((image_size, image_size), Image.AFFINE, (1, 0, 0, 0, 1, level))
 
 
 translate_y = TransformT('TranslateY', _translate_y_impl)
@@ -403,12 +403,12 @@ def _solarize_impl(pil_img, level):
 solarize = TransformT('Solarize', _solarize_impl)
 
 
-def _cutout_pil_impl(pil_img, level):
+def _cutout_pil_impl(pil_img, level, image_size):
     """Apply cutout to pil_img at the specified level."""
     size = int_parameter(level, 20)
     if size <= 0:
         return pil_img
-    img_height, img_width, num_channels = (32, 32, 3)
+    img_height, img_width, num_channels = (image_size, image_size, 3)
     _, upper_coord, lower_coord = (create_cutout_mask(img_height, img_width,
                                                       num_channels, size))
     pixels = pil_img.load()  # create the pixel map

--- a/pba/augmentation_transforms_hp.py
+++ b/pba/augmentation_transforms_hp.py
@@ -69,7 +69,7 @@ def apply_policy(policy, img, aug_policy, dset, image_size):
             assert count >= 0
             if count == 0:
                 break
-        return pil_unwrap(pil_img, dset)
+        return pil_unwrap(pil_img, dset, image_size)
     else:
         return img
 

--- a/pba/data_utils.py
+++ b/pba/data_utils.py
@@ -221,6 +221,8 @@ class DataSet(object):
         test_data = test_data.reshape(10000, 3072)
         train_data = train_data.reshape(-1, 3, 32, 32)
         test_data = test_data.reshape(-1, 3, 32, 32)
+        train_labels = np.array(train_labels, dtype=np.int32)
+        test_labels = np.array(test_labels, dtype=np.int32)
 
         self.test_images, self.test_labels = test_data, test_labels
         train_data, train_labels = shuffle_data(train_data, train_labels)
@@ -283,10 +285,10 @@ class DataSet(object):
         """Load random data and labels."""
         self.num_classes = 200
         self.train_images = np.random.random((hparams.train_size, 3, 224, 224))
-        self.val_images = np.random.random((hparams.val_size, 3, 224, 224))
+        self.val_images = np.random.random((hparams.validation_size, 3, 224, 224))
         self.test_images = np.random.random((hparams.test_size, 3, 224, 224))
         self.train_labels = np.random.randint(0, self.num_classes, (hparams.train_size))
-        self.val_labels = np.random.randint(0, self.num_classes, (hparams.val_size))
+        self.val_labels = np.random.randint(0, self.num_classes, (hparams.validation_size))
         self.test_labels = np.random.randint(0, self.num_classes, (hparams.test_size))
 
     def load_data(self, hparams):

--- a/pba/data_utils.py
+++ b/pba/data_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Data utils for CIFAR-10 and CIFAR-100."""
+"""Data utils."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -45,6 +45,16 @@ def parse_policy(policy_emb, augmentation_transforms):
     return policy
 
 
+def shuffle_data(data, labels):
+    """Shuffle data using numpy."""
+    np.random.seed(0)
+    perm = np.arange(len(data))
+    np.random.shuffle(perm)
+    data = data[perm]
+    labels = labels[perm]
+    return data, labels
+
+
 class DataSet(object):
     """Dataset object that produces augmented training and eval data."""
 
@@ -54,50 +64,40 @@ class DataSet(object):
         self.curr_train_index = 0
 
         self.parse_policy(hparams)
-        train_data, train_labels, self.test_images, self.test_labels = self.load_data(
-            hparams)
-        # Shuffle train data.
-        np.random.seed(0)
-        perm = np.arange(len(train_data))
-        np.random.shuffle(perm)
-        train_data = train_data[perm]
-        train_labels = train_labels[perm]
-        train_size, val_size = hparams.train_size, hparams.validation_size
+        self.load_data(hparams)
 
-        # Break off test data
-        if 'cifar' in hparams.dataset:
-            assert 50000 >= train_size + val_size
-            self.train_images = train_data[:train_size]
-            self.train_labels = train_labels[:train_size]
-            self.val_images = train_data[train_size:train_size + val_size]
-            self.val_labels = train_labels[train_size:train_size + val_size]
-            self.num_train = self.train_images.shape[0]
-        elif 'svhn' in hparams.dataset:
-            if hparams.dataset == 'svhn-full':
-                assert train_size + val_size <= 604388
-            else:
-                assert train_size + val_size <= 73257
-            self.train_images = train_data[:train_size]
-            self.train_labels = train_labels[:train_size]
-            self.val_images = train_data[-val_size:]
-            self.val_labels = train_labels[-val_size:]
-            self.num_train = self.train_images.shape[0]
+        # Apply normalization
+        self.train_images = self.train_images.transpose(0, 2, 3, 1) / 255.0
+        self.val_images = self.val_images.transpose(0, 2, 3, 1) / 255.0
+        self.test_images = self.test_images.transpose(0, 2, 3, 1) / 255.0
+        if not hparams.recompute_dset_stats:
+            mean = self.augmentation_transforms.MEANS[hparams.dataset + '_' +
+                                                      str(hparams.train_size)]
+            std = self.augmentation_transforms.STDS[hparams.dataset + '_' +
+                                                    str(hparams.train_size)]
+        else:
+            mean = self.train_images.mean(axis=(0, 1, 2))
+            std = self.train_images.std(axis=(0, 1, 2))
+        tf.logging.info('mean:{}    std: {}'.format(mean, std))
+
+        self.train_images = (self.train_images - mean) / std
+        self.val_images = (self.val_images - mean) / std
+        self.test_images = (self.test_images - mean) / std
 
         assert len(self.test_images) == len(self.test_labels)
         assert len(self.train_images) == len(self.train_labels)
-
-        tf.logging.info('train dataset size: {}, test: {}, val: {}'.format(
-            train_size, len(self.test_images), val_size))
         assert len(self.val_images) == len(self.val_labels)
+        tf.logging.info('train dataset size: {}, test: {}, val: {}'.format(
+            len(self.train_images), len(self.test_images), len(self.val_images)))
 
     def parse_policy(self, hparams):
         """Parses policy schedule from input, which can be a list, list of lists, text file, or pickled list.
 
-    If list is not nested, then uses the same policy for all epochs.
+        If list is not nested, then uses the same policy for all epochs.
 
-    Args:
-      hparams: tf.hparams object.
-    """
+        Args:
+        hparams: tf.hparams object.
+        """
         # Parse policy
         if hparams.use_hp_policy:
             import pba.augmentation_transforms_hp as augmentation_transforms
@@ -221,7 +221,16 @@ class DataSet(object):
         test_data = test_data.reshape(10000, 3072)
         train_data = train_data.reshape(-1, 3, 32, 32)
         test_data = test_data.reshape(-1, 3, 32, 32)
-        return train_data, train_labels, test_data, test_labels, num_classes
+
+        self.test_images, self.test_labels = test_data, test_labels
+        train_data, train_labels = shuffle_data(train_data, train_labels)
+        train_size, val_size = hparams.train_size, hparams.validation_size
+        assert 50000 >= train_size + val_size
+        self.train_images = train_data[:train_size]
+        self.train_labels = train_labels[:train_size]
+        self.val_images = train_data[train_size:train_size + val_size]
+        self.val_labels = train_labels[train_size:train_size + val_size]
+        self.num_classes = num_classes
 
     def load_svhn(self, hparams):
         train_labels = []
@@ -256,52 +265,67 @@ class DataSet(object):
             test_labels = test_loader.labels
         else:
             raise ValueError(hparams.dataset)
-        return train_data, train_labels, test_data, test_labels, num_classes
+
+        self.test_images, self.test_labels = test_data, test_labels
+        train_data, train_labels = shuffle_data(train_data, train_labels)
+        train_size, val_size = hparams.train_size, hparams.validation_size
+        if hparams.dataset == 'svhn-full':
+            assert train_size + val_size <= 604388
+        else:
+            assert train_size + val_size <= 73257
+        self.train_images = train_data[:train_size]
+        self.train_labels = train_labels[:train_size]
+        self.val_images = train_data[-val_size:]
+        self.val_labels = train_labels[-val_size:]
+        self.num_classes = num_classes
+
+    def load_test(self, hparams):
+        """Load random data and labels."""
+        self.num_classes = 200
+        self.train_images = np.random.random((hparams.train_size, 3, 224, 224))
+        self.val_images = np.random.random((hparams.val_size, 3, 224, 224))
+        self.test_images = np.random.random((hparams.test_size, 3, 224, 224))
+        self.train_labels = np.random.randint(0, self.num_classes, (hparams.train_size))
+        self.val_labels = np.random.randint(0, self.num_classes, (hparams.val_size))
+        self.test_labels = np.random.randint(0, self.num_classes, (hparams.test_size))
 
     def load_data(self, hparams):
         """Load raw data from specified dataset.
 
-    Args:
-      hparams: tf.hparams object.
+        Assumes data is in NCHW format.
 
-    Returns:
-      train_data: Training image data.
-      train_labels: Training ground truth labels.
-      test_data: Testing image data.
-      test_labels: Testing ground truth labels.
-    """
+        Populates:
+            self.train_images: Training image data.
+            self.train_labels: Training ground truth labels.
+            self.val_images: Validation/holdout image data.
+            self.val_labels: Validation/holdout ground truth labels.
+            self.test_images: Testing image data.
+            self.test_labels: Testing ground truth labels.
+            self.num_classes: Number of classes.
+            self.num_train: Number of training examples.
+
+        Args:
+            hparams: tf.hparams object.
+        """
         if hparams.dataset == 'cifar10' or hparams.dataset == 'cifar100':
-            train_data, train_labels, test_data, test_labels, num_classes = self.load_cifar(
-                hparams)
+            self.load_cifar(hparams)
         elif hparams.dataset == 'svhn' or hparams.dataset == 'svhn-full':
-            train_data, train_labels, test_data, test_labels, num_classes = self.load_svhn(
-                hparams)
+            self.load_svhn(hparams)
+        elif hparams.dataset == 'test':
+            self.load_test(hparams)
         else:
             raise ValueError('unimplemented')
-        train_data = train_data.transpose(0, 2, 3, 1) / 255.0
-        test_data = test_data.transpose(0, 2, 3, 1) / 255.0
-        if not hparams.recompute_dset_stats:
-            mean = self.augmentation_transforms.MEANS[hparams.dataset + '_' +
-                                                      str(hparams.train_size)]
-            std = self.augmentation_transforms.STDS[hparams.dataset + '_' +
-                                                    str(hparams.train_size)]
-        else:
-            mean = train_images.mean(axis=(0, 1, 2))
-            std = train_images.std(axis=(0, 1, 2))
-        tf.logging.info('mean:{}    std: {}'.format(mean, std))
 
-        train_data = (train_data - mean) / std
-        test_data = (test_data - mean) / std
-        train_labels = np.eye(num_classes)[np.array(
-            train_labels, dtype=np.int32)]
-        test_labels = np.eye(num_classes)[np.array(
-            test_labels, dtype=np.int32)]
-        assert len(train_data) == len(train_labels)
-        assert len(test_data) == len(test_labels)
-        tf.logging.info('In {} loader, number of images: {}'.format(
-            hparams.dataset,
-            len(train_data) + len(test_data)))
-        return train_data, train_labels, test_data, test_labels
+        self.num_train = self.train_images.shape[0]
+        self.train_labels = np.eye(self.num_classes)[np.array(
+            self.train_labels, dtype=np.int32)]
+        self.val_labels = np.eye(self.num_classes)[np.array(
+            self.val_labels, dtype=np.int32)]
+        self.test_labels = np.eye(self.num_classes)[np.array(
+            self.test_labels, dtype=np.int32)]
+        assert len(self.train_images) == len(self.train_labels)
+        assert len(self.val_images) == len(self.val_labels)
+        assert len(self.test_images) == len(self.test_labels)
 
     def next_batch(self, iteration=None):
         """Return the next minibatch of augmented data."""
@@ -364,12 +388,16 @@ class DataSet(object):
             else:
                 final_img = data
             if self.hparams.dataset == 'cifar10' or self.hparams.dataset == 'cifar100':
-                assert 'svhn' not in self.hparams.dataset
                 final_img = self.augmentation_transforms.random_flip(
                     self.augmentation_transforms.zero_pad_and_crop(
                         final_img, 4))
+            elif 'svhn' in self.hparams.dataset:
+                pass
             else:
-                assert 'svhn' in self.hparams.dataset
+                tf.logging.warn('Using default random flip and crop.')
+                final_img = self.augmentation_transforms.random_flip(
+                    self.augmentation_transforms.zero_pad_and_crop(
+                        final_img, 4))
             # Apply cutout
             if not self.hparams.no_cutout:
                 if 'cifar10' == self.hparams.dataset:
@@ -382,7 +410,9 @@ class DataSet(object):
                     final_img = self.augmentation_transforms.cutout_numpy(
                         final_img, size=20)
                 else:
-                    raise ValueError('Unknown dataset.')
+                    tf.logging.warn('Using default cutout size (16x16)')
+                    final_img = self.augmentation_transforms.cutout_numpy(
+                        final_img)
             final_imgs.append(final_img)
         batched_data = (np.array(final_imgs, np.float32), labels)
         self.curr_train_index += self.hparams.batch_size

--- a/pba/data_utils.py
+++ b/pba/data_utils.py
@@ -402,7 +402,7 @@ class DataSet(object):
             elif 'svhn' in self.hparams.dataset:
                 pass
             else:
-                tf.logging.log_first_n(tf.logging.WARN, 'Using default random flip and crop.', 3)
+                tf.logging.log_first_n(tf.logging.WARN, 'Using default random flip and crop.', 1)
                 final_img = self.augmentation_transforms.random_flip(
                     self.augmentation_transforms.zero_pad_and_crop(
                         final_img, 4))
@@ -418,7 +418,7 @@ class DataSet(object):
                     final_img = self.augmentation_transforms.cutout_numpy(
                         final_img, size=20)
                 else:
-                    tf.logging.log_first_n(tf.logging.WARN, 'Using default cutout size (16x16).', 3)
+                    tf.logging.log_first_n(tf.logging.WARN, 'Using default cutout size (16x16).', 1)
                     final_img = self.augmentation_transforms.cutout_numpy(
                         final_img)
             final_imgs.append(final_img)

--- a/pba/data_utils.py
+++ b/pba/data_utils.py
@@ -308,6 +308,7 @@ class DataSet(object):
             self.test_labels: Testing ground truth labels.
             self.num_classes: Number of classes.
             self.num_train: Number of training examples.
+            self.image_size: Width/height of image.
 
         Args:
             hparams: tf.hparams object.
@@ -322,6 +323,7 @@ class DataSet(object):
             raise ValueError('unimplemented')
 
         self.num_train = self.train_images.shape[0]
+        self.image_size = self.train_images.shape[2]
         self.train_labels = np.eye(self.num_classes)[np.array(
             self.train_labels, dtype=np.int32)]
         self.val_labels = np.eye(self.num_classes)[np.array(
@@ -331,6 +333,7 @@ class DataSet(object):
         assert len(self.train_images) == len(self.train_labels)
         assert len(self.val_images) == len(self.val_labels)
         assert len(self.test_images) == len(self.test_labels)
+        assert self.train_images.shape[2] == self.train_images.shape[3]
 
     def next_batch(self, iteration=None):
         """Return the next minibatch of augmented data."""
@@ -359,7 +362,7 @@ class DataSet(object):
                         epoch_policy,
                         data,
                         dset=dset,
-                        image_size=self.hparams.image_size)
+                        image_size=self.image_size)
                 else:
                     # apply PBA policy)
                     if isinstance(self.policy[0], list):
@@ -372,14 +375,14 @@ class DataSet(object):
                                 data,
                                 self.hparams.aug_policy,
                                 dset,
-                                image_size=self.hparams.image_size)
+                                image_size=self.image_size)
                         else:
                             final_img = self.augmentation_transforms.apply_policy(
                                 self.policy[iteration],
                                 data,
                                 self.hparams.aug_policy,
                                 dset,
-                                image_size=self.hparams.image_size)
+                                image_size=self.image_size)
                     elif isinstance(self.policy, list):
                         # policy schedule
                         final_img = self.augmentation_transforms.apply_policy(
@@ -387,7 +390,7 @@ class DataSet(object):
                             data,
                             self.hparams.aug_policy,
                             dset,
-                            image_size=self.hparams.image_size)
+                            image_size=self.image_size)
                     else:
                         raise ValueError('Unknown policy.')
             else:

--- a/pba/data_utils.py
+++ b/pba/data_utils.py
@@ -78,6 +78,8 @@ class DataSet(object):
         else:
             mean = self.train_images.mean(axis=(0, 1, 2))
             std = self.train_images.std(axis=(0, 1, 2))
+            self.augmentation_transforms.MEANS[hparams.dataset + '_' + str(hparams.train_size)] = mean
+            self.augmentation_transforms.STDS[hparams.dataset + '_' + str(hparams.train_size)] = std
         tf.logging.info('mean:{}    std: {}'.format(mean, std))
 
         self.train_images = (self.train_images - mean) / std
@@ -283,13 +285,14 @@ class DataSet(object):
 
     def load_test(self, hparams):
         """Load random data and labels."""
+        test_size = 200
         self.num_classes = 200
-        self.train_images = np.random.random((hparams.train_size, 3, 224, 224))
-        self.val_images = np.random.random((hparams.validation_size, 3, 224, 224))
-        self.test_images = np.random.random((hparams.test_size, 3, 224, 224))
+        self.train_images = np.random.random((hparams.train_size, 3, 224, 224)) * 255
+        self.val_images = np.random.random((hparams.validation_size, 3, 224, 224)) * 255
+        self.test_images = np.random.random((test_size, 3, 224, 224)) * 255
         self.train_labels = np.random.randint(0, self.num_classes, (hparams.train_size))
         self.val_labels = np.random.randint(0, self.num_classes, (hparams.validation_size))
-        self.test_labels = np.random.randint(0, self.num_classes, (hparams.test_size))
+        self.test_labels = np.random.randint(0, self.num_classes, (test_size))
 
     def load_data(self, hparams):
         """Load raw data from specified dataset.

--- a/pba/data_utils.py
+++ b/pba/data_utils.py
@@ -402,7 +402,7 @@ class DataSet(object):
             elif 'svhn' in self.hparams.dataset:
                 pass
             else:
-                tf.logging.warn('Using default random flip and crop.')
+                tf.logging.log_first_n(tf.logging.WARN, 'Using default random flip and crop.', 3)
                 final_img = self.augmentation_transforms.random_flip(
                     self.augmentation_transforms.zero_pad_and_crop(
                         final_img, 4))
@@ -418,7 +418,7 @@ class DataSet(object):
                     final_img = self.augmentation_transforms.cutout_numpy(
                         final_img, size=20)
                 else:
-                    tf.logging.warn('Using default cutout size (16x16)')
+                    tf.logging.log_first_n(tf.logging.WARN, 'Using default cutout size (16x16).', 3)
                     final_img = self.augmentation_transforms.cutout_numpy(
                         final_img)
             final_imgs.append(final_img)

--- a/pba/helper_utils.py
+++ b/pba/helper_utils.py
@@ -102,7 +102,7 @@ def get_lr(curr_epoch, hparams, iteration=None):
     else:
         lr = cosine_lr(hparams.lr, curr_epoch, iteration, batches_per_epoch,
                        hparams.num_epochs)
-        tf.logging.warn('Default to cosine learning rate.')
+        tf.logging.log_first_n(tf.logging.WARN, 'Default to cosine learning rate.', 1)
     return lr
 
 

--- a/pba/helper_utils.py
+++ b/pba/helper_utils.py
@@ -100,7 +100,9 @@ def get_lr(curr_epoch, hparams, iteration=None):
         lr = cosine_lr(hparams.lr, curr_epoch, iteration, batches_per_epoch,
                        hparams.num_epochs)
     else:
-        raise ValueError('unknown model+dataset')
+        lr = cosine_lr(hparams.lr, curr_epoch, iteration, batches_per_epoch,
+                       hparams.num_epochs)
+        tf.logging.warn('Default to cosine learning rate.')
     return lr
 
 

--- a/pba/model.py
+++ b/pba/model.py
@@ -97,9 +97,10 @@ def build_model(inputs, num_classes, is_training, hparams):
 class Model(object):
     """Builds an model."""
 
-    def __init__(self, hparams, num_classes):
+    def __init__(self, hparams, num_classes, image_size):
         self.hparams = hparams
         self.num_classes = num_classes
+        self.image_size = image_size
 
     def build(self, mode):
         """Construct the model."""
@@ -124,11 +125,11 @@ class Model(object):
         """Sets up image and label placeholders for the model."""
         if dataset == 'cifar10' or dataset == 'cifar100' or self.mode == 'train':
             self.images = tf.placeholder(tf.float32,
-                                         [self.batch_size, 32, 32, 3])
+                                         [self.batch_size, self.image_size, self.image_size, 3])
             self.labels = tf.placeholder(tf.float32,
                                          [self.batch_size, self.num_classes])
         else:
-            self.images = tf.placeholder(tf.float32, [None, 32, 32, 3])
+            self.images = tf.placeholder(tf.float32, [None, self.image_size, self.image_size, 3])
             self.labels = tf.placeholder(tf.float32, [None, self.num_classes])
 
     def assign_epoch(self, session, epoch_value):
@@ -281,12 +282,12 @@ class ModelTrainer(object):
         # Determine if we should build the train and eval model. When using
         # distributed training we only want to build one or the other and not both.
         with tf.variable_scope('model', use_resource=False):
-            m = Model(self.hparams, self.data_loader.num_classes)
+            m = Model(self.hparams, self.data_loader.num_classes, self.data_loader.image_size)
             m.build('train')
             self._num_trainable_params = m.num_trainable_params
             self._saver = m.saver
         with tf.variable_scope('model', reuse=True, use_resource=False):
-            meval = Model(self.hparams, self.data_loader.num_classes)
+            meval = Model(self.hparams, self.data_loader.num_classes, self.data_loader.image_size)
             meval.build('eval')
         self.m = m
         self.meval = meval

--- a/pba/model.py
+++ b/pba/model.py
@@ -97,8 +97,9 @@ def build_model(inputs, num_classes, is_training, hparams):
 class Model(object):
     """Builds an model."""
 
-    def __init__(self, hparams):
+    def __init__(self, hparams, num_classes):
         self.hparams = hparams
+        self.num_classes = num_classes
 
     def build(self, mode):
         """Construct the model."""
@@ -121,22 +122,14 @@ class Model(object):
 
     def _setup_images_and_labels(self, dataset):
         """Sets up image and label placeholders for the model."""
-        if dataset == 'cifar10' or dataset == 'svhn' or dataset == 'svhn-full':
-            self.num_classes = 10
-        elif dataset == 'cifar100':
-            self.num_classes = 100
-        else:
-            raise ValueError()
         if dataset == 'cifar10' or dataset == 'cifar100' or self.mode == 'train':
             self.images = tf.placeholder(tf.float32,
                                          [self.batch_size, 32, 32, 3])
             self.labels = tf.placeholder(tf.float32,
                                          [self.batch_size, self.num_classes])
-        elif 'svhn' in dataset:
+        else:
             self.images = tf.placeholder(tf.float32, [None, 32, 32, 3])
             self.labels = tf.placeholder(tf.float32, [None, self.num_classes])
-        else:
-            raise ValueError(dataset)
 
     def assign_epoch(self, session, epoch_value):
         session.run(
@@ -288,12 +281,12 @@ class ModelTrainer(object):
         # Determine if we should build the train and eval model. When using
         # distributed training we only want to build one or the other and not both.
         with tf.variable_scope('model', use_resource=False):
-            m = Model(self.hparams)
+            m = Model(self.hparams, self.data_loader.num_classes)
             m.build('train')
             self._num_trainable_params = m.num_trainable_params
             self._saver = m.saver
         with tf.variable_scope('model', reuse=True, use_resource=False):
-            meval = Model(self.hparams)
+            meval = Model(self.hparams, self.data_loader.num_classes)
             meval.build('eval')
         self.m = m
         self.meval = meval

--- a/pba/model.py
+++ b/pba/model.py
@@ -119,7 +119,7 @@ class Model(object):
         self.reuse = None if (mode == 'train') else True
         self.batch_size = self.hparams.batch_size
         if mode == 'eval':
-            self.batch_size = 25
+            self.batch_size = self.hparams.test_batch_size
 
     def _setup_images_and_labels(self, dataset):
         """Sets up image and label placeholders for the model."""

--- a/pba/setup.py
+++ b/pba/setup.py
@@ -127,7 +127,9 @@ def create_hparams(state, FLAGS):  # pylint: disable=invalid-name
         aug_policy=FLAGS.aug_policy,
         no_cutout=FLAGS.no_cutout,
         image_size=FLAGS.image_size,
-        recompute_dset_stats=FLAGS.recompute_dset_stats)
+        recompute_dset_stats=FLAGS.recompute_dset_stats,
+        lr=FLAGS.lr,
+        weight_decay_rate=FLAGS.wd)
 
     if state == 'train':
         hparams.add_hparam('no_aug', FLAGS.no_aug)

--- a/pba/setup.py
+++ b/pba/setup.py
@@ -27,7 +27,6 @@ def create_parser(state):
         '--dataset',
         default='cifar10',
         choices=('cifar10', 'cifar100', 'svhn', 'svhn-full', 'test'))
-    parser.add_argument('--image_size', type=int, default=32, help='Width/height of data.')
     parser.add_argument(
         '--recompute_dset_stats',
         action='store_true',
@@ -126,7 +125,6 @@ def create_hparams(state, FLAGS):  # pylint: disable=invalid-name
         explore=FLAGS.explore,
         aug_policy=FLAGS.aug_policy,
         no_cutout=FLAGS.no_cutout,
-        image_size=FLAGS.image_size,
         recompute_dset_stats=FLAGS.recompute_dset_stats,
         lr=FLAGS.lr,
         weight_decay_rate=FLAGS.wd)

--- a/pba/setup.py
+++ b/pba/setup.py
@@ -62,6 +62,7 @@ def create_parser(state):
     parser.add_argument('--lr', type=float, default=0.1, help='learning rate')
     parser.add_argument('--wd', type=float, default=0.0005, help='weight decay')
     parser.add_argument('--bs', type=int, default=128, help='batch size')
+    parser.add_argument('--test_bs', type=int, default=25, help='test batch size')
     parser.add_argument('--num_samples', type=int, default=1, help='Number of Ray samples')
 
     if state == 'train':
@@ -127,7 +128,8 @@ def create_hparams(state, FLAGS):  # pylint: disable=invalid-name
         no_cutout=FLAGS.no_cutout,
         recompute_dset_stats=FLAGS.recompute_dset_stats,
         lr=FLAGS.lr,
-        weight_decay_rate=FLAGS.wd)
+        weight_decay_rate=FLAGS.wd,
+        test_batch_size=FLAGS.test_bs)
 
     if state == 'train':
         hparams.add_hparam('no_aug', FLAGS.no_aug)

--- a/pba/setup.py
+++ b/pba/setup.py
@@ -26,18 +26,17 @@ def create_parser(state):
     parser.add_argument(
         '--dataset',
         default='cifar10',
-        choices=('cifar10', 'cifar100', 'svhn', 'svhn-full'))
-    parser.add_argument('--image_size', type=int, default=32)
+        choices=('cifar10', 'cifar100', 'svhn', 'svhn-full', 'test'))
+    parser.add_argument('--image_size', type=int, default=32, 'Width/height of data.')
     parser.add_argument(
         '--recompute_dset_stats',
         action='store_true',
         help='Instead of using hardcoded mean/std, recompute from dataset.')
-    parser.add_argument('--local_dir', type=str, default='/tmp/ray_results/')
-    parser.add_argument('--restore', type=str, default=None)
-    parser.add_argument('--use_cpu', action='store_true')
-    parser.add_argument('--train_size', type=int, default=5000)
-    parser.add_argument('--val_size', type=int, default=45000)
-    parser.add_argument('--checkpoint_freq', type=int, default=50)
+    parser.add_argument('--local_dir', type=str, default='/tmp/ray_results/',  help='Ray directory.')
+    parser.add_argument('--restore', type=str, default=None, help='If specified, tries to restore from given path.')
+    parser.add_argument('--train_size', type=int, default=5000, help='Number of training examples.')
+    parser.add_argument('--val_size', type=int, default=45000, help='Number of validation examples.')
+    parser.add_argument('--checkpoint_freq', type=int, default=50, help='Checkpoint frequency.')
     parser.add_argument(
         '--cpu', type=float, default=4, help='Allocated by Ray')
     parser.add_argument(
@@ -61,10 +60,10 @@ def create_parser(state):
         help='Number of epochs, or <=0 for default')
     parser.add_argument(
         '--no_cutout', action='store_true', help='turn off cutout')
-    parser.add_argument('--lr', type=float, default=-1.)
-    parser.add_argument('--wd', type=float, default=-1.)
-    parser.add_argument('--bs', type=int, default=128)
-    parser.add_argument('--num_samples', type=int, default=1)
+    parser.add_argument('--lr', type=float, default=0.1, help='learning rate')
+    parser.add_argument('--wd', type=float, default=0.0005, help='weight decay')
+    parser.add_argument('--bs', type=int, default=128, help='batch size')
+    parser.add_argument('--num_samples', type=int, default=1, help='Number of Ray samples')
 
     if state == 'train':
         parser.add_argument(
@@ -124,7 +123,6 @@ def create_hparams(state, FLAGS):  # pylint: disable=invalid-name
         data_path=FLAGS.data_path,
         batch_size=FLAGS.bs,
         gradient_clipping_by_global_norm=5.0,
-        use_cpu=FLAGS.use_cpu,
         explore=FLAGS.explore,
         aug_policy=FLAGS.aug_policy,
         no_cutout=FLAGS.no_cutout,
@@ -168,86 +166,34 @@ def create_hparams(state, FLAGS):  # pylint: disable=invalid-name
         epochs = 200
         hparams.add_hparam('wrn_size', 32)
         hparams.add_hparam('wrn_depth', 40)
-        if FLAGS.dataset == 'cifar10':
-            hparams.add_hparam('lr', 0.1)
-            hparams.add_hparam('weight_decay_rate', 5e-4)
-        elif FLAGS.dataset == 'svhn' or FLAGS.dataset == 'svhn-full':
-            hparams.add_hparam('lr', 0.005)
-            hparams.add_hparam('weight_decay_rate', 0.005)
-        else:
-            raise ValueError()
     elif FLAGS.model_name == 'wrn_28_10':
         hparams.add_hparam('model_name', 'wrn')
         epochs = 200
         hparams.add_hparam('wrn_size', 160)
         hparams.add_hparam('wrn_depth', 28)
-        if FLAGS.dataset == 'cifar100' or (FLAGS.dataset == 'cifar10'
-                                           and FLAGS.train_size == 50000):
-            hparams.add_hparam('lr', 0.1)
-            hparams.add_hparam('weight_decay_rate', 5e-4)
-        elif FLAGS.dataset == 'cifar10' and FLAGS.train_size == 4000:
-            hparams.add_hparam('lr', 0.05)
-            hparams.add_hparam('weight_decay_rate', 0.005)
-        elif FLAGS.dataset == 'svhn' or FLAGS.dataset == 'svhn-full':
-            hparams.add_hparam('lr', 0.005)
-            hparams.add_hparam('weight_decay_rate', 0.001)
-        else:
-            raise ValueError()
     elif FLAGS.model_name == 'resnet':
         hparams.add_hparam('model_name', 'resnet')
         epochs = 200
         hparams.add_hparam('resnet_size', 20)
         hparams.add_hparam('num_filters', FLAGS.resnet_size)
-        hparams.add_hparam('lr', 0.1)
-        hparams.add_hparam('weight_decay_rate', 5e-4)
     elif FLAGS.model_name == 'shake_shake_32':
         hparams.add_hparam('model_name', 'shake_shake')
         epochs = 1800
         hparams.add_hparam('shake_shake_widen_factor', 2)
-        hparams.add_hparam('lr', 0.01)
-        hparams.add_hparam('weight_decay_rate', 0.001)
     elif FLAGS.model_name == 'shake_shake_96':
         hparams.add_hparam('model_name', 'shake_shake')
         epochs = 1800
         hparams.add_hparam('shake_shake_widen_factor', 6)
-        if FLAGS.dataset == 'cifar100':
-            hparams.add_hparam('lr', 0.01)
-            hparams.add_hparam('weight_decay_rate', 0.0025)
-        elif FLAGS.dataset == 'cifar10' and FLAGS.train_size == 50000:
-            hparams.add_hparam('lr', 0.01)
-            hparams.add_hparam('weight_decay_rate', 0.001)
-        elif FLAGS.dataset == 'cifar10' and FLAGS.train_size == 4000:
-            hparams.add_hparam('lr', 0.025)
-            hparams.add_hparam('weight_decay_rate', 0.0025)
-        elif FLAGS.dataset == 'svhn' or FLAGS.dataset == 'svhn-full':
-            hparams.add_hparam('lr', 0.01)  # or 0.01
-            hparams.add_hparam('weight_decay_rate', 0.00015)
-        else:
-            raise ValueError()
     elif FLAGS.model_name == 'shake_shake_112':
         hparams.add_hparam('model_name', 'shake_shake')
         epochs = 1800
         hparams.add_hparam('shake_shake_widen_factor', 7)
-        hparams.add_hparam('lr', 0.01)
-        hparams.add_hparam('weight_decay_rate', 0.001)
     elif FLAGS.model_name == 'pyramid_net':
         hparams.add_hparam('model_name', 'pyramid_net')
         epochs = 1800
-        if FLAGS.dataset == 'cifar100':
-            hparams.add_hparam('lr', 0.025)
-            hparams.add_hparam('weight_decay_rate', 5e-4)
-        elif FLAGS.dataset == 'cifar10':
-            hparams.add_hparam('lr', 0.05)
-            hparams.add_hparam('weight_decay_rate', 5e-5)
-        else:
-            raise ValueError()
         hparams.set_hparam('batch_size', 64)
     else:
         raise ValueError('Not Valid Model Name: %s' % FLAGS.model_name)
-    if FLAGS.lr > 0:
-        hparams.set_hparam('lr', FLAGS.lr)
-    if FLAGS.wd > 0:
-        hparams.set_hparam('weight_decay_rate', FLAGS.wd)
     if FLAGS.epochs > 0:
         tf.logging.info('overwriting with custom epochs')
         epochs = FLAGS.epochs

--- a/pba/setup.py
+++ b/pba/setup.py
@@ -27,7 +27,7 @@ def create_parser(state):
         '--dataset',
         default='cifar10',
         choices=('cifar10', 'cifar100', 'svhn', 'svhn-full', 'test'))
-    parser.add_argument('--image_size', type=int, default=32, 'Width/height of data.')
+    parser.add_argument('--image_size', type=int, default=32, help='Width/height of data.')
     parser.add_argument(
         '--recompute_dset_stats',
         action='store_true',

--- a/scripts/test_search.sh
+++ b/scripts/test_search.sh
@@ -5,9 +5,10 @@ python pba/search.py \
     --local_dir "$PWD/results/" \
     --model_name wrn_40_2 \
     --dataset test \
-    --train_size 1000 --val_size 1000 \
+    --train_size 200 --val_size 200 \
     --checkpoint_freq 0 \
     --name "test_search" --gpu 0.15 --cpu 2 \
-    --num_samples 16 --perturbation_interval 3 --epochs 60 \
+    --num_samples 4 --perturbation_interval 3 --epochs 30 \
     --explore cifar10 --aug_policy cifar10 \
-    --lr 0.1 --wd 0.0005
+    --lr 0.1 --wd 0.0005 --bs 16 --recompute_dset_stats
+

--- a/scripts/test_search.sh
+++ b/scripts/test_search.sh
@@ -5,10 +5,10 @@ python pba/search.py \
     --local_dir "$PWD/results/" \
     --model_name wrn_40_2 \
     --dataset test \
-    --train_size 200 --val_size 200 \
+    --train_size 50 --val_size 50 \
     --checkpoint_freq 0 \
-    --name "test_search" --gpu 0.15 --cpu 2 \
+    --name "test_search" --gpu 0.49 --cpu 2 \
     --num_samples 4 --perturbation_interval 3 --epochs 30 \
     --explore cifar10 --aug_policy cifar10 \
-    --lr 0.1 --wd 0.0005 --bs 16 --recompute_dset_stats
+    --lr 0.1 --wd 0.0005 --bs 2 --test_bs 2 --recompute_dset_stats
 

--- a/scripts/test_search.sh
+++ b/scripts/test_search.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+export PYTHONPATH="$(pwd)"
+
 python pba/search.py \
     --local_dir "$PWD/results/" \
     --model_name wrn_40_2 \

--- a/scripts/test_search.sh
+++ b/scripts/test_search.sh
@@ -1,0 +1,10 @@
+python pba/search.py \
+    --local_dir "$PWD/results/" \
+    --model_name wrn_40_2 \
+    --dataset test \
+    --train_size 1000 --val_size 1000 \
+    --checkpoint_freq 0 \
+    --name "test_search" --gpu 0.15 --cpu 2 \
+    --num_samples 16 --perturbation_interval 3 --epochs 60 \
+    --explore cifar10 --aug_policy cifar10 \
+    --lr 0.1 --wd 0.0005


### PR DESCRIPTION
Add `scripts/test_search.sh` to test with random noise data and 224x224 image size. Removes many hardcoded assumptions about SVHN or CIFAR. Adding a new dataset should now only require loading the data arrays in the dataloader object of `pba/data_utils.py`

(needs lint)